### PR TITLE
Updated terraform script to use patched version

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -327,11 +327,8 @@ variable "builder_image" {
       us-west-2 = "ami-938420f3"
       # Just plain ubuntu images here for now
       # From https://cloud-images.ubuntu.com/locator/ec2/
-      # Note: these were commented out when we updated our builder_images to
-      # patch CVE-2016-5195 (http://dirtycow.ninja/)
-
-      # cn-north-1      = "ami-0679b06b"
-      # us-gov-west-1   = "ami-30b8da13"
+      cn-north-1      = "ami-92f622ff"
+      us-gov-west-1   = "ami-34df6755"
     }
 }
 

--- a/circleci.tf
+++ b/circleci.tf
@@ -315,20 +315,23 @@ variable "base_services_image" {
 
 variable "builder_image" {
     default = {
-      ap-northeast-1  = "ami-c7c838a6"
-      ap-northeast-2  = "ami-b477bcda"
-      ap-southeast-1  = "ami-5775a734"
-      ap-southeast-2  = "ami-654e6506"
-      eu-central-1    = "ami-3401ea5b"
-      eu-west-1       = "ami-2237ad51"
-      sa-east-1       = "ami-8360f5ef"
-      us-east-1       = "ami-564df541"
-      us-west-1       = "ami-0b4a0d6b"
-      us-west-2       = "ami-b1a667d1"
+      ap-northeast-1 = "ami-59389e38"
+      ap-northeast-2 = "ami-a2e236cc"
+      ap-southeast-1 = "ami-a80fa9cb"
+      ap-southeast-2 = "ami-53241930"
+      eu-central-1 = "ami-5a59a035"
+      eu-west-1 = "ami-e0c78993"
+      sa-east-1 = "ami-3832af54"
+      us-east-1 = "ami-d0396bc7"
+      us-west-1 = "ami-76226916"
+      us-west-2 = "ami-938420f3"
       # Just plain ubuntu images here for now
       # From https://cloud-images.ubuntu.com/locator/ec2/
-      cn-north-1      = "ami-0679b06b"
-      us-gov-west-1   = "ami-30b8da13"
+      # Note: these were commented out when we updated our builder_images to
+      # patch CVE-2016-5195 (http://dirtycow.ninja/)
+
+      # cn-north-1      = "ami-0679b06b"
+      # us-gov-west-1   = "ami-30b8da13"
     }
 }
 


### PR DESCRIPTION
This partially patches CVE-2016-5195 (http://dirtycow.ninja/). Services
boxes should be updated manually.