### PR TITLE
Giving public ip address to builder ASG

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -376,6 +376,7 @@ resource "aws_launch_configuration" "builder_lc" {
     # 4x or 8x are best
     instance_type = "${var.builder_instance_type}"
 
+    associate_public_ip_address = true
 
     image_id = "${lookup(var.builder_image, var.aws_region)}"
     key_name = "${var.aws_ssh_key_name}"


### PR DESCRIPTION
I couldn't make builder machines to reach the internet without this configuration. It's possible that I'm missing something, though, so feedback is welcome.