### PR TITLE
Support Replicated 2.x

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -356,7 +356,7 @@ resource "aws_instance" "services" {
 
 replicated -version || curl https://s3.amazonaws.com/circleci-enterprise/init-services.sh | bash
 
-config_dir=/etc/circle-config
+config_dir=/var/lib/replicated/circle-config
 mkdir -p $config_dir
 echo ${var.circle_secret_passphrase} > $config_dir/circle_secret_passphrase
 echo ${aws_sqs_queue.shutdown_queue.id} > $config_dir/sqs_queue_url


### PR DESCRIPTION
Tiny change to support Replicated 2. We have to use a path that is accessible to the replicated docker container. (We should come up with a better mechanism in the future instead of shoehorning things into Replicated data dirs.)