### PR TITLE
Adds option to disable public IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Optional vars:
   | enable_route | enable creating a Route53 route for the Services box | 0 |
   | route_name | Route name to configure for Services box | "" |
   | route_zone_id | Zone to configure route in | "" |
+  | associate_public_ip_address | Allows the ability to disable public IP for the service box in AWS | "true" |

--- a/circleci.tf
+++ b/circleci.tf
@@ -84,6 +84,11 @@ variable "route_zone_id" {
   default     = ""
 }
 
+variable "associate_public_ip_address" {
+  description = "denotes if the instance will be accessible via a public ip address"
+  default.    = "true"
+}
+
 data "aws_subnet" "subnet" {
   id = "${var.aws_subnet_id}"
 }
@@ -402,7 +407,7 @@ resource "aws_instance" "services" {
   ami                         = "${var.services_ami != "" ? var.services_ami : lookup(var.ubuntu_ami, var.aws_region)}"
   key_name                    = "${var.aws_ssh_key_name}"
   subnet_id                   = "${var.aws_subnet_id}"
-  associate_public_ip_address = true
+  associate_public_ip_address = "${var.associate_public_ip_address"
   disable_api_termination     = true
   iam_instance_profile        = "${aws_iam_instance_profile.circleci_profile.name}"
 

--- a/circleci.tf
+++ b/circleci.tf
@@ -407,7 +407,7 @@ resource "aws_instance" "services" {
   ami                         = "${var.services_ami != "" ? var.services_ami : lookup(var.ubuntu_ami, var.aws_region)}"
   key_name                    = "${var.aws_ssh_key_name}"
   subnet_id                   = "${var.aws_subnet_id}"
-  associate_public_ip_address = "${var.associate_public_ip_address"
+  associate_public_ip_address = "${var.associate_public_ip_address}"
   disable_api_termination     = true
   iam_instance_profile        = "${aws_iam_instance_profile.circleci_profile.name}"
 


### PR DESCRIPTION
This PR adds a variable to the `tfvars` option so that a user can disable a public IP in AWS when standing up via a terraform