### PR TITLE
Public IPs for builders

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -461,6 +461,7 @@ resource "aws_launch_configuration" "builder_lc" {
   image_id             = "${lookup(var.ubuntu_ami, var.aws_region)}"
   key_name             = "${var.aws_ssh_key_name}"
   iam_instance_profile = "${aws_iam_instance_profile.circleci_profile.name}"
+  associate_public_ip_address = true
 
   security_groups = ["${aws_security_group.circleci_builders_sg.id}",
     "${aws_security_group.circleci_builders_admin_sg.id}",

--- a/nomad-cluster.tf
+++ b/nomad-cluster.tf
@@ -84,6 +84,7 @@ resource "aws_launch_configuration" "clients_lc" {
   instance_type = "${var.nomad_client_instance_type}"
   image_id      = "${lookup(var.ubuntu_ami, var.aws_region)}"
   key_name      = "${var.aws_ssh_key_name}"
+  associate_public_ip_address = true
 
   root_block_device = {
     volume_type = "gp2"


### PR DESCRIPTION
This adds public IPs for builders by default the same way we do for services box. Often necessary on VPCs that don't do it by default but don't have NATs so that the builders can bootstrap themselves.