### PR TITLE
Remove .terraform from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.tfvars
 .ansible/
 **.retry
+/.terraform


### PR DESCRIPTION
Added the `.terraform` dir into .gitignore, because it's annoying seeing it in `git status`

![example_of_git_status](https://user-images.githubusercontent.com/473071/30582702-97787280-9d1c-11e7-8e63-d7460ac939d5.png)