### PR TITLE
Tighten Services security groups

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -257,6 +257,12 @@ resource "aws_security_group" "circleci_services_sg" {
   #}
 }
 
+resource "aws_security_group" "circleci_services_nomad_sg" {
+  name        = "${var.prefix}_services_nomad_sg"
+  description = "SG for Nomad servers to access CircleCI services"
+  vpc_id      = "${var.aws_vpc_id}"
+}
+
 resource "aws_security_group" "circleci_builders_admin_sg" {
   name        = "${var.prefix}_builders_admin_sg"
   description = "SG for services to masters communication - avoids circular dependency"
@@ -307,30 +313,6 @@ resource "aws_security_group" "circleci_users_sg" {
     protocol    = "tcp"
     from_port   = 8800
     to_port     = 8800
-  }
-
-  # For Nomad server in 2.0 clustered installation
-  ingress {
-    cidr_blocks = ["${data.aws_subnet.subnet.cidr_block}"]
-    protocol    = "tcp"
-    from_port   = 4647
-    to_port     = 4647
-  }
-
-  # For output-processor in 2.0 clustered installation
-  ingress {
-    cidr_blocks = ["${data.aws_subnet.subnet.cidr_block}"]
-    protocol    = "tcp"
-    from_port   = 8585
-    to_port     = 8585
-  }
-
-  # For build-agent to talk to vm-service
-  ingress {
-    cidr_blocks = ["${data.aws_subnet.subnet.cidr_block}"]
-    protocol    = "tcp"
-    from_port   = 3001
-    to_port     = 3001
   }
 
   # For SSH traffic to builder boxes
@@ -408,6 +390,7 @@ resource "aws_instance" "services" {
 
   vpc_security_group_ids = [
     "${aws_security_group.circleci_services_sg.id}",
+    "${aws_security_group.circleci_services_nomad_sg.id}",
     "${aws_security_group.circleci_users_sg.id}",
   ]
 

--- a/nomad-cluster.tf
+++ b/nomad-cluster.tf
@@ -71,7 +71,74 @@ resource "aws_security_group" "ssh_sg" {
 #   }
 # }
 
-data "template_file" "nomad_user_data"{
+# We do this with rules so that we can handle "var.enable_nomad" being off
+# For Nomad server connections from Nomad servers in 2.0 clustered installation
+resource "aws_security_group_rule" "services_nomad_4647" {
+  count                    = "${var.enable_nomad}"
+  type                     = "ingress"
+  source_security_group_id = "${aws_security_group.nomad_sg.id}"
+  security_group_id        = "${aws_security_group.circleci_services_nomad_sg.id}"
+  protocol                 = "tcp"
+  from_port                = 4647
+  to_port                  = 4647
+}
+
+# For Nomad server connections from Docker VMs in 2.0 clustered installation
+resource "aws_security_group_rule" "services_vms_4647" {
+  count                    = "${var.enable_nomad}"
+  type                     = "ingress"
+  source_security_group_id = "${aws_security_group.circleci_vm_sg.id}"
+  security_group_id        = "${aws_security_group.circleci_services_nomad_sg.id}"
+  protocol                 = "tcp"
+  from_port                = 4647
+  to_port                  = 4647
+}
+
+# For output-processor connections from Nomad servers in 2.0 clustered installation
+resource "aws_security_group_rule" "services_nomad_8585" {
+  count                    = "${var.enable_nomad}"
+  type                     = "ingress"
+  source_security_group_id = "${aws_security_group.nomad_sg.id}"
+  security_group_id        = "${aws_security_group.circleci_services_nomad_sg.id}"
+  protocol                 = "tcp"
+  from_port                = 8585
+  to_port                  = 8585
+}
+
+# For output-processor connections from Docker VMs in 2.0 clustered installation
+resource "aws_security_group_rule" "services_vms_8585" {
+  count                    = "${var.enable_nomad}"
+  type                     = "ingress"
+  source_security_group_id = "${aws_security_group.circleci_vm_sg.id}"
+  security_group_id        = "${aws_security_group.circleci_services_nomad_sg.id}"
+  protocol                 = "tcp"
+  from_port                = 8585
+  to_port                  = 8585
+}
+
+# For build-agent connections from Nomad servers in 2.0 clustered installation
+resource "aws_security_group_rule" "services_nomad_3001" {
+  count                    = "${var.enable_nomad}"
+  type                     = "ingress"
+  source_security_group_id = "${aws_security_group.nomad_sg.id}"
+  security_group_id        = "${aws_security_group.circleci_services_nomad_sg.id}"
+  protocol                 = "tcp"
+  from_port                = 3001
+  to_port                  = 3001
+}
+
+# For build-agent connections from Docker VMs in 2.0 clustered installation
+resource "aws_security_group_rule" "services_vms_3001" {
+  count                    = "${var.enable_nomad}"
+  type                     = "ingress"
+  source_security_group_id = "${aws_security_group.circleci_vm_sg.id}"
+  security_group_id        = "${aws_security_group.circleci_services_nomad_sg.id}"
+  protocol                 = "tcp"
+  from_port                = 3001
+  to_port                  = 3001
+}
+
+data "template_file" "nomad_user_data" {
   template = "${file("templates/nomad_user_data.tpl")}"
 
   vars {


### PR DESCRIPTION
Get rid of CIDR blocks for Nomad and vm server connections.
We're using security groups everything, so we should be able to limit connections to security groups.

This change creates a new security group for the services box, and then if we enable Nomad (through "var.enable_nomad"),
it adds security group rules for 4647 (Nomad), 8585 (output-processor), 3001 (build-agent) from both Nomad and VM servers.

Was quite annoyed that those rules were initially stuck into the "services_users" SG.

cc @bellkev 