### PR TITLE
Rollback docker to 17.03.2

### DIFF
--- a/templates/builders_user_data.tpl
+++ b/templates/builders_user_data.tpl
@@ -23,7 +23,7 @@ apt-get install -y apt-transport-https ca-certificates curl
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update
-apt-get -y install docker-ce=17.06.0~ce-0~ubuntu cgmanager
+apt-get -y install docker-ce=17.03.2~ce-0~ubuntu cgmanager
 
 echo "-------------------------------------------"
 echo "      Pulling Server Builder Image"

--- a/templates/nomad_user_data.tpl
+++ b/templates/nomad_user_data.tpl
@@ -15,7 +15,7 @@ apt-get install -y apt-transport-https ca-certificates curl
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update
-apt-get -y install docker-ce=17.06.0~ce-0~ubuntu cgmanager
+apt-get -y install docker-ce=17.03.2~ce-0~ubuntu cgmanager
 
 echo "--------------------------------------"
 echo "   Creating ci-privileged network"

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -22,7 +22,7 @@ echo "--------------------------------------------"
 echo "       Installing Replicated"
 echo "--------------------------------------------"
 sleep 3
-bash /tmp/get_replicated.sh local-address="$PRIVATE_IP" no-proxy docker-version="17.06.0"
+bash /tmp/get_replicated.sh local-address="$PRIVATE_IP" no-proxy docker-version="17.03.2"
 
 echo "--------------------------------------------"
 echo "       Passing Variables"


### PR DESCRIPTION
We have had a number of issues with containers ending up `dead` in 17.06 rolling back to 17.03.2 appears to resolve this issue. 