### PR TITLE
Makes it easy to include as module

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -104,7 +104,7 @@ data "aws_subnet" "subnet" {
 }
 
 data "template_file" "services_user_data" {
-  template = "${file("templates/services_user_data.tpl")}"
+  template = "${file("${path.module}/templates/services_user_data.tpl")}"
 
   vars {
     circle_secret_passphrase = "${var.circle_secret_passphrase}"
@@ -120,7 +120,7 @@ data "template_file" "services_user_data" {
 }
 
 data "template_file" "builders_user_data" {
-  template = "${file("templates/builders_user_data.tpl")}"
+  template = "${file("${path.module}/templates/builders_user_data.tpl")}"
 
   vars {
     services_private_ip      = "${aws_instance.services.private_ip}"
@@ -132,7 +132,7 @@ data "template_file" "builders_user_data" {
 }
 
 data "template_file" "circleci_policy" {
-  template = "${file("templates/circleci_policy.tpl")}"
+  template = "${file("${path.module}/templates/circleci_policy.tpl")}"
 
   vars {
     bucket_arn    = "${aws_s3_bucket.circleci_bucket.arn}"
@@ -143,7 +143,7 @@ data "template_file" "circleci_policy" {
 }
 
 data "template_file" "shutdown_queue_role_policy" {
-  template = "${file("templates/shutdown_queue_role_policy.tpl")}"
+  template = "${file("${path.module}/templates/shutdown_queue_role_policy.tpl")}"
 
   vars {
     sqs_queue_arn = "${aws_sqs_queue.shutdown_queue.arn}"
@@ -151,7 +151,7 @@ data "template_file" "shutdown_queue_role_policy" {
 }
 
 data "template_file" "output" {
-  template = "${file("templates/output.tpl")}"
+  template = "${file("${path.module}/templates/output.tpl")}"
 
   vars {
     services_public_ip = "${aws_instance.services.public_ip}"
@@ -178,7 +178,7 @@ resource "aws_sqs_queue" "shutdown_queue" {
 
 resource "aws_iam_role" "shutdown_queue_role" {
   name               = "${var.prefix}_shutdown_queue_role"
-  assume_role_policy = "${file("files/shutdown_queue_role.json")}"
+  assume_role_policy = "${file("${path.module}/files/shutdown_queue_role.json")}"
 }
 
 resource "aws_iam_role_policy" "shutdown_queue_role_policy" {
@@ -206,7 +206,7 @@ resource "aws_s3_bucket" "circleci_bucket" {
 resource "aws_iam_role" "circleci_role" {
   name               = "${var.prefix}_role"
   path               = "/"
-  assume_role_policy = "${file("files/circleci_role.json")}"
+  assume_role_policy = "${file("${path.module}/files/circleci_role.json")}"
 }
 
 resource "aws_iam_role_policy" "circleci_policy" {

--- a/nomad-cluster.tf
+++ b/nomad-cluster.tf
@@ -72,7 +72,7 @@ resource "aws_security_group" "ssh_sg" {
 # }
 
 data "template_file" "nomad_user_data"{
-  template = "${file("templates/nomad_user_data.tpl")}"
+  template = "${file("${path.module}/templates/nomad_user_data.tpl")}"
 
   vars {
     nomad_server = "${aws_instance.services.private_ip}"


### PR DESCRIPTION
I maintain a single repo that has all of the terraform definitions we use to stand up infrastructure at work. I attempted to include this project as a module so that I could keep my configuration consolidated in a single repo/statefile/etc. The first problem I hit was that all of the `${file("...")}` references were relative. This first set of changes fixes that problem and still works as a standalone project.

The other change I was required to make was to set variables inside of my top-level `main.tf` file where I include the module. I think adding some docs around "how to include this module" would be useful and I'm happy to add those changes as well.  Please let me know.

e.g. **main.tf** 

```hcl
# this is where i stitch together all of the modules we leverage

module "ccie" {
    source = "ccie"

    aws_access_key = "..."
    aws_secret_key = "..."
    aws_region = "..."
    aws_vpc_id = "vpc-..."
    aws_subnet_id = "subnet-..."
    aws_ssh_key_name = "..."
    circle_secret_passphrase = "..."
    services_instance_type = "c4.2xlarge"
    builder_instance_type = "r3.4xlarge"
}
```