### PR TITLE
[CIRCLE-7415] Add permission to start and stop instances

### DIFF
--- a/templates/circleci_policy.tpl
+++ b/templates/circleci_policy.tpl
@@ -46,6 +46,8 @@
           },
           {
               "Action": [
+                  "ec2:StartInstances",
+                  "ec2:StopInstances"
                   "ec2:TerminateInstances",
                   "ec2:AttachVolume",
                   "ec2:DetachVolume",


### PR DESCRIPTION
This is required in order to use the reusable docker machine.