### PR TITLE
Do not start 1.0 builders for new deploys

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -45,8 +45,13 @@ variable "builder_instance_type" {
 }
 
 variable "max_builders_count" {
-  description = "max number of builders"
+  description = "max number of 1.0 builders"
   default     = "2"
+}
+
+variable "desired_builders_count" {
+  description = "desired number of 1.0 builders"
+  default     = "1"
 }
 
 variable "prefix" {
@@ -511,7 +516,7 @@ resource "aws_autoscaling_group" "builder_asg" {
   launch_configuration = "${aws_launch_configuration.builder_lc.name}"
   max_size             = "${var.max_builders_count}"
   min_size             = 0
-  desired_capacity     = 1
+  desired_capacity     = "${var.desired_builders_count}"
   force_delete         = true
 
   tag {

--- a/terraform.tfvars-dev.template
+++ b/terraform.tfvars-dev.template
@@ -8,6 +8,7 @@ circle_secret_passphrase = "..."
 services_instance_type = "c4.2xlarge"
 builder_instance_type = "t2.2xlarge"
 nomad_client_instance_type = "t2.2xlarge"
+desired_builders_count = "1"
 
 # Provide proxy address if your network configuration requires it
 http_proxy = ""

--- a/terraform.tfvars.template
+++ b/terraform.tfvars.template
@@ -22,6 +22,9 @@ nomad_client_instance_type = "m4.xlarge"
 # 3. Optional Cloud Configuration
 #####################################
 
+# Set this to `1` or higher to enable CircleCI 1.0 builders
+desired_builders_count = "0"
+
 # Provide proxy address if your network configuration requires it
 http_proxy = ""
 https_proxy = ""


### PR DESCRIPTION
This commit makes the number of 1.0 builders configurable, and sets this to 0 in the terraform template.
The default is 1, to prevent breaking existing usages of enterprise-setup. Need to confirm how some stuff works in Server deploys before I can actually merge this.