### PR TITLE
change from_protocol to from_port on github sg

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -283,14 +283,14 @@ resource "aws_security_group" "circleci_services_sg" {
   #ingress {
   #    security_groups = ["192.30.252.0/22"]
   #    protocol = "tcp"
-  #    from_protocol = 443
-  #    to_protocol = 443
+  #    from_port = 443
+  #    to_port = 443
   #}
   #ingress {
   #    security_groups = ["192.30.252.0/22"]
   #    protocol = "tcp"
-  #    from_protocol = 80
-  #    to_protocol = 80
+  #    from_port = 80
+  #    to_port = 80
   #}
 }
 


### PR DESCRIPTION
The current github sg has `(from|to)_protocol` instead of `(from|to)_port`