### PR TITLE
Use cidr_blocks instead of security_groups

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -281,13 +281,13 @@ resource "aws_security_group" "circleci_services_sg" {
   # https://help.github.com/articles/what-ip-addresses-does-github-use-that-i-should-whitelist/
   #
   #ingress {
-  #    security_groups = ["192.30.252.0/22"]
+  #    cidr_blocks = ["192.30.252.0/22"]
   #    protocol = "tcp"
   #    from_protocol = 443
   #    to_protocol = 443
   #}
   #ingress {
-  #    security_groups = ["192.30.252.0/22"]
+  #    cidr_blocks = ["192.30.252.0/22"]
   #    protocol = "tcp"
   #    from_protocol = 80
   #    to_protocol = 80


### PR DESCRIPTION
These should use cidr_blocks instead of security_groups, since we're passing cidr blocks.