### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Optional vars:
   | Var      | Description | Default |
   | -------- | ----------- | ------- |
   | services_instance_type | Instance type for the centralized services box.  We recommend a c4 instance | c4.2xlarge |
-  | builder_instance_type | Instance type for the builder machines.  We recommend a r3 instance | r3.2xlarge |
-  | max_builders_count | Max number of builders | 2 |
-  | nomad_client_instance_type | Instance type for the nomad clients. We recommend a XYZ instance | m4.xlarge |
+  | builder_instance_type | Instance type for the 1.0 builder machines.  We recommend a r3 instance | r3.2xlarge |
+  | max_builders_count | Max number of 1.0 builders | 2 |
+  | nomad_client_instance_type | Instance type for the nomad clients (2.0 builders). We recommend a XYZ instance | m4.xlarge |
   | max_clients_count | Max number of nomad clients | 2 |
   | prefix   | Prefix for resource names | circleci |
   | enable_nomad | Provisions a nomad cluster for CCIE v2 | 1 |


### PR DESCRIPTION
PR based on [feedback from customer](https://circleci.zendesk.com/agent/tickets/30370). he said:

> The Settings screen clearly says: "The selection below will not turn on the builders themselves, so please see the documentation for information on provisioning your builder resources.” So how do I turn on the 1.0 builders?

& this was a situation where he already had his 1.0 builders enabled !! 😕

basically, it's unclear what is meant by "the documentation"—looking here, we don't even clarify which instances are 1.0 builders vs. 2.0 builders. (neither do we do so [here](circleci.com/docs/2.0/overview), which is [also a problem](https://github.com/circleci/circleci-docs/issues/2070).)