### PR TITLE
Update terraform.tfvars.template

### DIFF
--- a/terraform.tfvars.template
+++ b/terraform.tfvars.template
@@ -16,7 +16,7 @@ aws_ssh_key_name = "..."
 circle_secret_passphrase = "..."
 services_instance_type = "m4.2xlarge"
 builder_instance_type = "r3.4xlarge"
-nomad_client_instance_type = "m4.xlarge"
+nomad_client_instance_type = "m4.2xlarge"
 
 #####################################
 # 3. Optional Cloud Configuration


### PR DESCRIPTION
bump default nomad client instance type (the previous default, `m4.xlarge`, wasn't even large enough to accommodate all our `resource_class` options: https://circleci.com/docs/2.0/configuration-reference/#resource_class)