### PR TITLE
Upgrade the default instance type for the services box to m4.2xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             echo "aws_subnet_id = \"subnet-495dd410\"" >> terraform.tfvars
             echo "aws_ssh_key_name = \"$CCIE_AWS_SSH_KEY\"" >> terraform.tfvars
             echo "prefix = \"enterprise_setup_test\"" >> terraform.tfvars
-            echo "services_instance_type = \"m4.xlarge\"" >> terraform.tfvars
+            echo "services_instance_type = \"m4.2xlarge\"" >> terraform.tfvars
             echo "builder_instance_type = \"r3.2xlarge\"" >> terraform.tfvars
             echo "nomad_client_instance_type = \"m4.xlarge\"" >> terraform.tfvars
             echo "circle_secret_passphrase = \"$CCIE_SECRET_PASSPHRASE\"" >> terraform.tfvars

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Optional vars:
 
   | Var      | Description | Default |
   | -------- | ----------- | ------- |
-  | services_instance_type | Instance type for the centralized services box.  We recommend a c4 instance | c4.2xlarge |
+  | services_instance_type | Instance type for the centralized services box.  We recommend a m4 instance | m4.2xlarge |
   | builder_instance_type | Instance type for the 1.0 builder machines.  We recommend a r3 instance | r3.2xlarge |
   | max_builders_count | Max number of 1.0 builders | 2 |
   | nomad_client_instance_type | Instance type for the nomad clients (2.0 builders). We recommend a XYZ instance | m4.xlarge |

--- a/circleci.tf
+++ b/circleci.tf
@@ -275,7 +275,6 @@ resource "aws_security_group" "circleci_vm_sg" {
 }
 
 resource "aws_instance" "services" {
-  # Instance type - any of the c4 should do for now
   instance_type               = "${var.services_instance_type}"
   ami                         = "${var.services_ami != "" ? var.services_ami : lookup(var.ubuntu_ami, var.aws_region)}"
   key_name                    = "${var.aws_ssh_key_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -32,8 +32,8 @@ variable "services_ami" {
 }
 
 variable "services_instance_type" {
-  description = "instance type for the centralized services box.  We recommend a c4 instance"
-  default     = "c4.2xlarge"
+  description = "instance type for the centralized services box.  We recommend a m4.2xlarge instance, with 32G of RAM"
+  default     = "m4.2xlarge"
 }
 
 variable "builder_instance_type" {


### PR DESCRIPTION
For the Services box, we are currently recommending an instance with at least 32GB of RAM. Therefore changing all references of `c4.2xlarge` (16GB) and `m4.xlarge` (16GB) to `m4.2xlarge` (32GB).

[Link](https://aws.amazon.com/ec2/instance-types/) to AWS instance types list.