### PR TITLE
fix: add increased JVM heap size

### DIFF
--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -33,6 +33,11 @@ apt-get update
 apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-trusty cgmanager
 
 echo "--------------------------------------------"
+echo "       Increasing JVM Heap Size"
+echo "--------------------------------------------"
+echo 'JAVA_OPTS="-Xms8g -Xmx8g"' >> /etc/environment
+
+echo "--------------------------------------------"
 echo "       Installing Replicated"
 echo "--------------------------------------------"
 sleep 3


### PR DESCRIPTION
Our enterprise instance recently expreienced the `frontend` container throwing an Out of Memory error for Java. After talking with @ryanwohara , we have agreed to increase the JVM size by default. This change would set it to 8GB minimum. It isn't perfect, and may need a range. This would prevent Enterprise companies from crashing too early at scale.