### PR TITLE
add ubuntu AMI for ca-central-1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,7 @@ variable "ubuntu_ami" {
     ap-northeast-2 = "ami-cd78d8a3"
     ap-southeast-1 = "ami-c38bf8bf"
     ap-southeast-2 = "ami-a437cac6"
+    ca-central-1   = "ami-c1a227a5"
     eu-central-1   = "ami-ff30a290"
     eu-west-1      = "ami-3cf36145"
     eu-west-2      = "ami-fd47a59a"


### PR DESCRIPTION
This addresses issue #100 by including the required base AMI (Ubuntu 14.04) for ca-central-1

I've stood up an instance there using this and all jobs in reality-check are passing. 

Internal ID: CIRCLE-12739