### PR TITLE
[Do not merge][CIRCLE-11418] Set Nomad client name to instance ID

### DIFF
--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -39,9 +39,11 @@ echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
 export PRIVATE_IP="$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+export INSTANCE_ID="$(curl http://169.254.169.254/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl
 log_level = "DEBUG"
+name = "$INSTANCE_ID"
 
 data_dir = "/opt/nomad"
 datacenter = "us-east-1"

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -5,6 +5,7 @@ set -exu
 export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
 export no_proxy="${no_proxy}"
+export INSTANCE_ID="$(curl http://169.254.169.254/latest/meta-data/instance-id)"
 
 echo "-------------------------------------------"
 echo "     Performing System Updates"
@@ -39,7 +40,6 @@ echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
 export PRIVATE_IP="$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
-export INSTANCE_ID="$(curl http://169.254.169.254/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl
 log_level = "DEBUG"

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -5,7 +5,7 @@ set -exu
 export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
 export no_proxy="${no_proxy}"
-export INSTANCE_ID="$(curl http://169.254.169.254/latest/meta-data/instance-id)"
+export aws_instance_metadata_url="http://169.254.169.254"
 
 echo "-------------------------------------------"
 echo "     Performing System Updates"
@@ -40,6 +40,7 @@ echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
 export PRIVATE_IP="$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+export INSTANCE_ID="$(curl http://$aws_instance_metadata_url/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl
 log_level = "DEBUG"


### PR DESCRIPTION
## Changes
This PR updates the nomad config file to set the name of Nomad client nodes to its corresponding AWS instance ID.