### PR TITLE
[Do not merge][CIRCLE-11050,RE-51] Open port 8125

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -229,7 +229,7 @@ resource "aws_security_group" "circleci_users_sg" {
 
   # For receiving Nomad Telemetry via StatsD
   ingress {
-    security_groups = ["${module.nomad.client_security_group_name}"]
+    security_groups = ["${module.nomad.client_security_group_id}"]
     protocol        = "udp"
     from_port       = 8125
     to_port         = 8125

--- a/circleci.tf
+++ b/circleci.tf
@@ -227,6 +227,14 @@ resource "aws_security_group" "circleci_users_sg" {
     to_port     = 3001
   }
 
+  # For receiving Nomad Telemetry via StatsD
+  ingress {
+    security_groups = ["${module.nomad.client_security_group_name}"]
+    protocol        = "udp"
+    from_port       = 8125
+    to_port         = 8125
+   }
+
   # For SSH traffic to builder boxes
   # TODO: Update once services box has ngrok
   ingress {

--- a/modules/nomad/outputs.tf
+++ b/modules/nomad/outputs.tf
@@ -2,8 +2,8 @@ output "asg_name" {
   value = "${aws_autoscaling_group.clients_asg.name}"
 }
 
-output "client_security_group_name" {
-  value = "${aws_security_group.nomad_sg.name}"
+output "client_security_group_id" {
+  value = "${aws_security_group.nomad_sg.id}"
 }
 
 output "ssh_security_group_name" {


### PR DESCRIPTION
## Problem
We need to expose UDP port 8125 on the Services Box to Nomad clients.

## Solution
Port 8125 is now exposed to Nomad clients with an ingress rule added in `circleci.tf`.

<img width="634" alt="screen shot 2018-08-02 at 1 00 49 pm" src="https://user-images.githubusercontent.com/7967489/43611023-c07cfc66-965c-11e8-8b5b-f940328ec14f.png">


## Notes
Changed `client_security_group_name` to `client_security_group_id`, as no one was using the variable anyway 🤷‍♀️ 