### PR TITLE
[Do not merge][CIRCLE-11418] Set Nomad client name to instance ID v2

### DIFF
--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -5,6 +5,7 @@ set -exu
 export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
 export no_proxy="${no_proxy}"
+export aws_instance_metadata_url="http://169.254.169.254"
 
 echo "-------------------------------------------"
 echo "     Performing System Updates"
@@ -39,22 +40,20 @@ echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
 export PRIVATE_IP="$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+export INSTANCE_ID="$(curl $aws_instance_metadata_url/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl
 log_level = "DEBUG"
-
+name = "$INSTANCE_ID"
 data_dir = "/opt/nomad"
 datacenter = "us-east-1"
-
 advertise {
     http = "$PRIVATE_IP"
     rpc = "$PRIVATE_IP"
     serf = "$PRIVATE_IP"
 }
-
 client {
     enabled = true
-
     # Expecting to have DNS record for nomad server(s)
     servers = ["${nomad_server}:4647"]
     node_class = "linux-64bit"
@@ -68,7 +67,6 @@ echo "--------------------------------------"
 cat <<EOT > /etc/init/nomad.conf
 start on filesystem or runlevel [2345]
 stop on shutdown
-
 script
     exec nomad agent -config /etc/nomad/config.hcl
 end script


### PR DESCRIPTION
## Changes
This PR updates the nomad config file to set the name of Nomad client nodes to its corresponding AWS instance ID.

## Note
This is a second version of the PR, as the first was accidentally merged.