### PR TITLE
Working xenial install

### DIFF
--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -14,7 +14,7 @@ apt-get update && apt-get -y upgrade
 echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
-apt-get install -y linux-image-extra-virtual
+apt-get install -y "linux-image-extra-$(uname -r)" linux-image-extra-virtual
 apt-get install -y apt-transport-https ca-certificates curl
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -14,7 +14,7 @@ apt-get update && apt-get -y upgrade
 echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
-apt-get install -y "linux-image-extra-$(uname -r)" linux-image-extra-virtual
+apt-get install -y "linux-image-$(uname -r)" linux-image-extra-virtual
 apt-get install -y apt-transport-https ca-certificates curl
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -69,11 +69,12 @@ cat <<EOT > /etc/systemd/system/nomad.service
 [Unit]
 Description=Nomad
 Documentation=https://nomadproject.io/docs/
-
 [Service]
-ExecStart=/usr/bin/nomad agent -config /etc/nomad/config.hcl
+KillMode=process
+KillSignal=SIGINT
+ExecStart=/usr/bin/nomad agent -config /etc/nomad
+ExecReload=/bin/kill -HUP \$MAINPID
 LimitNOFILE=65536
-
 [Install]
 WantedBy=multi-user.target
 EOT

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -25,7 +25,7 @@ curl -sSk -o /tmp/get_replicated.sh "https://get.replicated.com/docker?replicate
 echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
-apt-get install -y "linux-image-extra-$(uname -r)" linux-image-extra-virtual
+apt-get install -y "linux-image-$(uname -r)" linux-image-extra-virtual
 apt-get install -y apt-transport-https ca-certificates curl
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -25,7 +25,7 @@ curl -sSk -o /tmp/get_replicated.sh "https://get.replicated.com/docker?replicate
 echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
-apt-get install -y linux-image-extra-virtual
+apt-get install -y "linux-image-extra-$(uname -r)" linux-image-extra-virtual
 apt-get install -y apt-transport-https ca-certificates curl
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"

--- a/variables.tf
+++ b/variables.tf
@@ -119,22 +119,19 @@ variable "legacy_builder_spot_price" {
 
 variable "ubuntu_ami" {
   default = {
-    ap-northeast-1 = "ami-2d69f14b"
-    ap-northeast-2 = "ami-cd78d8a3"
-    ap-southeast-1 = "ami-c38bf8bf"
-    ap-southeast-2 = "ami-a437cac6"
-    eu-central-1   = "ami-ff30a290"
-    eu-west-1      = "ami-3cf36145"
-    sa-east-1      = "ami-24642648"
-
-    # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180122
-    us-east-1      = "ami-263d0b5c"
-
-    # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180122
-    us-east-2      = "ami-218da744"
-
-    us-west-1      = "ami-98595af8"
-    us-west-2      = "ami-779a2d0f"
+    # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180814
+    ap-northeast-1 = "ami-02115cef40fbb46a4"   
+    ap-northeast-2 = "ami-00ca7ffe117e2fe91"
+    ap-southeast-1 = "ami-03221428e6676db69"
+    ap-southeast-2 = "ami-059b78064586da1b7"
+    eu-central-1   = "ami-027583e616ca104df"
+    eu-west-1      = "ami-0181f8d9b6f098ec4"
+    eu-west-2      = "ami-c7ab5fa0"
+    sa-east-1      = "ami-08b78b890b5a86161"
+    us-east-1      = "ami-04169656fea786776"
+    us-east-2      = "ami-0552e3455b9bc8d50"
+    us-west-1      = "ami-059e7901352ebaef8"
+    us-west-2      = "ami-51537029"
   }
 }
 


### PR DESCRIPTION
@heug & i just went over this—i spun up a new server install w/ it & got green realitycheck

obviously we shouldn't merge w/o changelogging for a server release, but i think we should aim for 2.15 or 2.16 here if possible (not that it would affect existing installations—but just to keep things organized)

@junejung doesn't seem to be anything in Jira for this work—can we get something created for tracking purposes ?

## changes
- `linux-image-extra` package naming conventions
- docker package (`trusty` to `xenial`)
- virtual network interface name changes b/w `trusty` & `xenial` (`eth0` doesn't exist in xenial)
- different way of starting nomad service
- bumped all amis to latest `ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server` images in all regions