### PR TITLE
[CIRCLE-13383] Upgrade Replicated to Latest Version for Fresh Installation

### DIFF
--- a/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
+++ b/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
@@ -8,6 +8,7 @@ UNAME="$(uname -r)"
 export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
 export no_proxy="${no_proxy}"
+export DEBIAN_FRONTEND=noninteractive
 
 echo "-------------------------------------------"
 echo "     Performing System Updates"

--- a/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
+++ b/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
@@ -3,6 +3,7 @@
 set -exu
 
 BUILDER_IMAGE="circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37"
+UNAME="$(uname -r)"
 
 export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
@@ -16,12 +17,12 @@ apt-get update && apt-get -y upgrade
 echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
-apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
-apt-get install -y apt-transport-https ca-certificates curl
+apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-trusty cgmanager
+apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-xenial
 
 sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
 sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -6,6 +6,7 @@ export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
 export no_proxy="${no_proxy}"
 export aws_instance_metadata_url="http://169.254.169.254"
+UNAME="$(uname -r)"
 
 echo "-------------------------------------------"
 echo "     Performing System Updates"
@@ -15,12 +16,12 @@ apt-get update && apt-get -y upgrade
 echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
-apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
-apt-get install -y apt-transport-https ca-certificates curl
+apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-trusty cgmanager
+apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-xenial
 
 sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
 sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -6,6 +6,7 @@ export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
 export no_proxy="${no_proxy}"
 export aws_instance_metadata_url="http://169.254.169.254"
+export DEBIAN_FRONTEND=noninteractive
 UNAME="$(uname -r)"
 
 echo "-------------------------------------------"

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -65,12 +65,16 @@ EOT
 echo "--------------------------------------"
 echo "      Creating nomad.conf"
 echo "--------------------------------------"
-cat <<EOT > /etc/init/nomad.conf
-start on filesystem or runlevel [2345]
-stop on shutdown
-script
-    exec nomad agent -config /etc/nomad/config.hcl
-end script
+cat <<EOT > /etc/systemd/system/nomad.service
+[Unit]
+Description="nomad"
+[Service]
+Restart=always
+RestartSec=30
+TimeoutStartSec=1m
+ExecStart=/usr/bin/nomad agent -config /etc/nomad/config.hcl
+[Install]
+WantedBy=multi-user.target
 EOT
 
 echo "--------------------------------------"

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -39,7 +39,7 @@ mv nomad /usr/bin
 echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
-export PRIVATE_IP="$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+export PRIVATE_IP="$(/sbin/ifconfig ens3 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
 export INSTANCE_ID="$(curl $aws_instance_metadata_url/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -exu
-REPLICATED_VERSION="2.10.3"
+REPLICATED_VERSION="2.29.0"
 
 export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -7,6 +7,7 @@ UNAME="$(uname -r)"
 export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
 export no_proxy="${no_proxy}"
+export DEBIAN_FRONTEND=noninteractive
 
 echo "-------------------------------------------"
 echo "     Performing System Updates"

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -2,6 +2,7 @@
 
 set -exu
 REPLICATED_VERSION="2.29.0"
+UNAME="$(uname -r)"
 
 export http_proxy="${http_proxy}"
 export https_proxy="${https_proxy}"
@@ -25,12 +26,12 @@ curl -sSk -o /tmp/get_replicated.sh "https://get.replicated.com/docker?replicate
 echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
-apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
-apt-get install -y apt-transport-https ca-certificates curl
+apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update
-apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-trusty cgmanager
+apt-get install -y "linux-image-$UNAME"
+apt-get -y install docker-ce="17.12.1~ce-0~ubuntu"
 
 echo "--------------------------------------------"
 echo "       Installing Replicated"

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -15,7 +15,7 @@ apt-get update && apt-get -y upgrade
 echo "--------------------------------------------"
 echo "       Setting Private IP"
 echo "--------------------------------------------"
-export PRIVATE_IP="$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+export PRIVATE_IP="$(/sbin/ifconfig ens3 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
 
 echo "--------------------------------------------"
 echo "          Download Replicated"

--- a/variables.tf
+++ b/variables.tf
@@ -119,19 +119,23 @@ variable "legacy_builder_spot_price" {
 
 variable "ubuntu_ami" {
   default = {
-    ap-northeast-1 = "ami-2d69f14b"
-    ap-northeast-2 = "ami-cd78d8a3"
-    ap-southeast-1 = "ami-c38bf8bf"
-    ap-southeast-2 = "ami-a437cac6"
-    ca-central-1   = "ami-c1a227a5"
-    eu-central-1   = "ami-ff30a290"
-    eu-west-1      = "ami-3cf36145"
-    eu-west-2      = "ami-fd47a59a"
-    sa-east-1      = "ami-24642648"
-    us-east-1      = "ami-0ce3bb76"
-    us-east-2      = "ami-01664c64"
-    us-west-1      = "ami-98595af8"
-    us-west-2      = "ami-779a2d0f"
+    ap-northeast-1 = "ami-032b53ea1222f69eb"
+    ap-northeast-2 = "ami-013dda6d4ad165475"
+    ap-northeast-3 = "ami-0e751e4aa374cd8c2"
+    ap-southeast-1 = "ami-0b4d63df52bb04cb3"
+    ap-southeast-2 = "ami-0df84623c5651856b"
+    ap-south-1     = "ami-0a01bf036d8cf964c"
+    ca-central-1   = "ami-0855ce2497d6ac2d9"
+    eu-central-1   = "ami-00259791f61937520"
+    eu-west-1      = "ami-00cc9e3eecbef4b46"
+    eu-west-2      = "ami-04a46267269408754"
+    eu-west-3      = "ami-0d682f9e8c835173d"
+    sa-east-1      = "ami-065d2aa938a7eb3eb"
+    us-east-1      = "ami-0f9351b59be17920e"
+    us-east-2      = "ami-0b19eeac8c68a0d2d"
+    us-west-1      = "ami-0e066bd33054ef120"
+    us-west-2      = "ami-0afae182eed9d2b46"
   }
 }
+
 


### PR DESCRIPTION
- Upgrade Replicated to 2.29.0 and Docker to 17.12.1 on the services box
- Upgrade base AMI's to Ubuntu 16.04 LTS and adjust installer scripts to account for new version.