### PR TITLE
Use splat syntax for outputs

### DIFF
--- a/modules/nomad/outputs.tf
+++ b/modules/nomad/outputs.tf
@@ -1,15 +1,15 @@
 output "asg_name" {
-  value = "${aws_autoscaling_group.clients_asg.name}"
+  value = "${aws_autoscaling_group.clients_asg.*.name}"
 }
 
 output "client_security_group_name" {
-  value = "${aws_security_group.nomad_sg.name}"
+  value = "${aws_security_group.nomad_sg.*.name}"
 }
 
 output "ssh_security_group_name" {
-  value = "${aws_security_group.ssh_sg.name}"
+  value = "${aws_security_group.ssh_sg.*.name}"
 }
 
 output "client_launch_config_name" {
-  value = "${aws_launch_configuration.clients_lc.name}"
+  value = "${aws_launch_configuration.clients_lc.*.name}"
 }

--- a/modules/nomad/outputs.tf
+++ b/modules/nomad/outputs.tf
@@ -1,15 +1,15 @@
 output "asg_name" {
-  value = "${aws_autoscaling_group.clients_asg.*.name}"
+  value = "${var.enabled ? aws_autoscaling_group.clients_asg.*.name[0] : ""}"
 }
 
 output "client_security_group_name" {
-  value = "${aws_security_group.nomad_sg.*.name}"
+  value = "${var.enabled ? aws_security_group.nomad_sg.*.name[0] : ""}"
 }
 
 output "ssh_security_group_name" {
-  value = "${aws_security_group.ssh_sg.*.name}"
+  value = "${var.enabled ? aws_security_group.ssh_sg.*.name[0] : ""}"
 }
 
 output "client_launch_config_name" {
-  value = "${aws_launch_configuration.clients_lc.*.name}"
+  value = "${var.enabled ? aws_launch_configuration.clients_lc.*.name[0] : ""}"
 }


### PR DESCRIPTION
These are list items, so splat syntax is the proper form. It'll remove the warnings and ensure future compatibility.