### PR TITLE
fix terraform warnings

### DIFF
--- a/modules/nomad/outputs.tf
+++ b/modules/nomad/outputs.tf
@@ -1,15 +1,15 @@
 output "asg_name" {
-  value = "${aws_autoscaling_group.clients_asg.name}"
+  value = "${aws_autoscaling_group.clients_asg.*.name}"
 }
 
 output "client_security_group_name" {
-  value = "${aws_security_group.nomad_sg.name}"
+  value = "${aws_security_group.nomad_sg.*.name}"
 }
 
 output "ssh_security_group_name" {
-  value = "${aws_security_group.ssh_sg.name}"
+  value = "${aws_security_group.ssh_sg.*.name}"
 }
 
 output "client_launch_config_name" {
-  value = "${aws_launch_configuration.clients_lc.name}"
+  value = "${aws_launch_configuration.clients_lc.*.name}"
 }


### PR DESCRIPTION
Modified nomad/output.tf in order not to receive following 4 warnings if you execute terraform `v0.11.10`.

```
Warning: output "asg_name": must use splat syntax to access aws_autoscaling_group.clients_asg attribute "name", because it has "count" set; use aws_autoscaling_group.clients_asg.*.name to obtain a list of the attributes across all instances

Warning: output "client_security_group_name": must use splat syntax to access aws_security_group.nomad_sg attribute "name", because it has "count" set; use aws_security_group.nomad_sg.*.name to obtain a list of the attributes across all instances

Warning: output "ssh_security_group_name": must use splat syntax to access aws_security_group.ssh_sg attribute "name", because it has "count" set; use aws_security_group.ssh_sg.*.name to obtain a list of the attributes across all instances

Warning: output "client_launch_config_name": must use splat syntax to access aws_launch_configuration.clients_lc attribute "name", because it has "count" set; use aws_launch_configuration.clients_lc.*.name to obtain a list of the attributes across all instances
```
Related Issue:
https://github.com/hashicorp/terraform/issues/16864