### PR TITLE
Use TF to locate the latest Ubuntu 16.04 AMI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,54 +45,8 @@ jobs:
           name: Run the plan
           command: terraform plan
 
-  validate_amis:
-    docker:
-      - image: iynere/enterprise-setup:latest
-    working_directory: ~/enterprise-setup
-    steps:
-      - checkout
-
-      - run:
-          name: setup AWS creds
-          working_directory: ~/
-          command: |
-            mkdir .aws
-            echo "[default]" > .aws/credentials
-            echo "aws_access_key_id = $CCIE_AWS_ACCESS_KEY" >> .aws/credentials
-            echo "aws_secret_access_key = $CCIE_AWS_SECRET_KEY" >> .aws/credentials
-            echo "[default]" > .aws/config
-
-      - run:
-          name: setup tmp AMIs list
-          command: cat variables.tf | grep "ami-" | tr -d " " | tr -d '"' > /tmp/amilist.txt
-
-      - run:
-          name: generate test file
-          command: bash test/setup.sh > test/amis.bats
-
-      - run:
-          name: test AMIs
-          command: |
-            mkdir -p test_results/bats
-            bats test/amis.bats | \
-            perl /tap-to-junit-xml/tap-to-junit-xml > \
-            test_results/bats/results.xml
-
-      - store_test_results:
-          path: test_results
-
-      - store_artifacts:
-          path: test_results
-
-      - store_artifacts:
-          path: test
-
-      - store_artifacts:
-          path: /tmp
-
 workflows:
   version: 2
   test:
     jobs:
       - terraform
-      - validate_amis

--- a/circleci.tf
+++ b/circleci.tf
@@ -276,7 +276,7 @@ resource "aws_security_group" "circleci_vm_sg" {
 
 resource "aws_instance" "services" {
   instance_type               = "${var.services_instance_type}"
-  ami                         = "${var.services_ami != "" ? var.services_ami : lookup(var.ubuntu_ami, var.aws_region)}"
+  ami                         = "${var.services_ami != "" ? var.services_ami : data.aws_ami.ubuntu.id}"
   key_name                    = "${var.aws_ssh_key_name}"
   subnet_id                   = "${var.aws_subnet_id}"
   associate_public_ip_address = true
@@ -347,7 +347,7 @@ module "legacy_builder" {
 
   user_data                     = "${module.legacy_builder_user_data.rendered}"
   delete_volume_on_termination  = "${var.services_delete_on_termination}"
-  image_id                      = "${lookup(var.ubuntu_ami, var.aws_region)}"
+  image_id                      = "data.aws_ami.ubuntu.id"
   instance_type                 = "${var.builder_instance_type}"
   spot_price                    = "${var.legacy_builder_spot_price}"
   shutdown_queue_target_sqs_arn = "${module.shutdown_sqs.sqs_arn}"
@@ -365,7 +365,7 @@ module "nomad" {
   http_proxy            = "${var.http_proxy}"
   https_proxy           = "${var.https_proxy}"
   no_proxy              = "${var.no_proxy}"
-  ami_id                = "${(var.services_ami != "") ? var.services_ami : lookup(var.ubuntu_ami, var.aws_region)}"
+  ami_id                = "${(var.services_ami != "") ? var.services_ami : data.aws_ami.ubuntu.id}"
   aws_subnet_cidr_block = "${data.aws_subnet.subnet.cidr_block}"
   services_private_ip   = "${aws_instance.services.private_ip}"
 }

--- a/ubuntu_ami.tf
+++ b/ubuntu_ami.tf
@@ -1,0 +1,15 @@
+data "aws_ami" "ubuntu" {
+    most_recent = true
+
+    filter {
+        name   = "name"
+        values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+    }
+
+    filter {
+        name   = "virtualization-type"
+        values = ["hvm"]
+    }
+
+    owners = ["099720109477"] # Canonical
+}


### PR DESCRIPTION
Rather than having to lookup a list of Ubuntu AMI and manually update the variable in the variables.tf file, we can use the [aws_ami data source](https://www.terraform.io/docs/providers/aws/d/ami.html) and look up the latest AMI.

Right now its set to look up based on the following parameters:
- OS: Ubuntu 16.04
- Architecture: amd64
- Volume Type: hvm-ssd
