### PR TITLE
CIRCLE-16271 apply patch for CVE 2019-5736

### DIFF
--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -24,6 +24,12 @@ apt-get install -y "linux-image-$UNAME"
 apt-get update
 apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-xenial
 
+# force docker to use userns-remap to mitigate CVE 2019-5736
+apt-get -y install jq
+tmp=$(mktemp)
+cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
+jq '."userns-remap": "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
+
 sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
 sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker
 sudo echo 'export no_proxy="${no_proxy}"' >> /etc/default/docker

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -30,7 +30,7 @@ mkdir -p /etc/docker
 [ -f /etc/docker/daemon.json ] || echo '{}' > /etc/docker/daemon.json
 tmp=$(mktemp)
 cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
-jq '."userns-remap"= "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
+jq '.["userns-remap"]="default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
 
 sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
 sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -28,7 +28,7 @@ apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-xenial
 apt-get -y install jq
 tmp=$(mktemp)
 cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
-jq '."userns-remap": "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
+jq '."userns-remap"= "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
 
 sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
 sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -26,6 +26,8 @@ apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-xenial
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq
+mkdir -p /etc/docker
+[ -f /etc/docker/daemon.json ] || echo '{}' > /etc/docker/daemon.json
 tmp=$(mktemp)
 cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
 jq '."userns-remap"= "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json


### PR DESCRIPTION
Adjust the cloud init script that installs Docker for CVE 2019-5736

This change uses jq to add a single entry to the installed docker config file

Doesn't assume the presence of jq
Saves the original file to /etc/docker/daemon.json.orig
Assumes:
- the path for the docker config is /etc/docker/daemon.json
- we are able to write to the above file