### PR TITLE
Configure timesyncd

### DIFF
--- a/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
+++ b/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
@@ -16,6 +16,11 @@ echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
 echo "--------------------------------------"
+echo "        Set clocksource to tsc"
+echo "--------------------------------------"
+echo "tsc" > /sys/devices/system/clocksource/clocksource0/current_clocksource
+
+echo "--------------------------------------"
 echo "        Creating timesyncd.conf"
 echo "--------------------------------------"
 cat <<EOT > /etc/systemd/timesyncd.conf

--- a/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
+++ b/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
@@ -16,6 +16,20 @@ echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
 echo "--------------------------------------"
+echo "        Creating timesyncd.conf"
+echo "--------------------------------------"
+cat <<EOT > /etc/systemd/timesyncd.conf
+[Time]
+NTP=169.254.169.123
+#FallbackNTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org
+EOT
+
+echo "--------------------------------------"
+echo "           Restart timesyncd"
+echo "--------------------------------------"
+sudo systemctl restart systemd-timesyncd.service
+
+echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
 apt-get install -y apt-transport-https ca-certificates curl software-properties-common

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -15,6 +15,20 @@ echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
 echo "--------------------------------------"
+echo "        Creating timesyncd.conf"
+echo "--------------------------------------"
+cat <<EOT > /etc/systemd/timesyncd.conf
+[Time]
+NTP=169.254.169.123
+#FallbackNTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org
+EOT
+
+echo "--------------------------------------"
+echo "           Restart timesyncd"
+echo "--------------------------------------"
+sudo systemctl restart systemd-timesyncd.service
+
+echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
 apt-get install -y apt-transport-https ca-certificates curl software-properties-common

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -15,6 +15,11 @@ echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
 echo "--------------------------------------"
+echo "        Set clocksource to tsc"
+echo "--------------------------------------"
+echo "tsc" > /sys/devices/system/clocksource/clocksource0/current_clocksource
+
+echo "--------------------------------------"
 echo "        Creating timesyncd.conf"
 echo "--------------------------------------"
 cat <<EOT > /etc/systemd/timesyncd.conf

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -14,6 +14,20 @@ echo "     Performing System Updates"
 echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
+echo "--------------------------------------"
+echo "        Creating timesyncd.conf"
+echo "--------------------------------------"
+cat <<EOT > /etc/systemd/timesyncd.conf
+[Time]
+NTP=169.254.169.123
+#FallbackNTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org
+EOT
+
+echo "--------------------------------------"
+echo "           Restart timesyncd"
+echo "--------------------------------------"
+sudo systemctl restart systemd-timesyncd.service
+
 echo "--------------------------------------------"
 echo "       Setting Private IP"
 echo "--------------------------------------------"

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -15,6 +15,11 @@ echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
 echo "--------------------------------------"
+echo "        Set clocksource to tsc"
+echo "--------------------------------------"
+echo "tsc" > /sys/devices/system/clocksource/clocksource0/current_clocksource
+
+echo "--------------------------------------"
 echo "        Creating timesyncd.conf"
 echo "--------------------------------------"
 cat <<EOT > /etc/systemd/timesyncd.conf


### PR DESCRIPTION
Uses AWS NTP 169.254.169.123 as per documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html