### PR TITLE
Add NTP Service to Services Box, Nomad Client, and Legacy Builders

### DIFF
--- a/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
+++ b/modules/legacy-builder-cloudinit-ubuntu-docker-v1/templates/builders_user_data.tpl
@@ -16,6 +16,29 @@ echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
 echo "--------------------------------------"
+echo "        Installing NTP"
+echo "--------------------------------------"
+apt-get install -y ntp
+
+# Use AWS NTP config for EC2 instances and default for non-AWS
+if [ -f /sys/hypervisor/uuid ] && [ `head -c 3 /sys/hypervisor/uuid` == ec2 ]; then
+cat <<EOT > /etc/ntp.conf
+driftfile /var/lib/ntp/ntp.drift
+disable monitor
+
+restrict default ignore
+restrict 127.0.0.1 mask 255.0.0.0
+restrict 169.254.169.123 nomodify notrap
+
+server 169.254.169.123 prefer iburst
+EOT
+else
+  echo "USING DEFAULT NTP CONFIGURATION"
+fi
+
+service ntp restart
+
+echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
 apt-get install -y apt-transport-https ca-certificates curl software-properties-common

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -15,6 +15,29 @@ echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
 echo "--------------------------------------"
+echo "        Installing NTP"
+echo "--------------------------------------"
+apt-get install -y ntp
+
+# Use AWS NTP config for EC2 instances and default for non-AWS
+if [ -f /sys/hypervisor/uuid ] && [ `head -c 3 /sys/hypervisor/uuid` == ec2 ]; then
+cat <<EOT > /etc/ntp.conf
+driftfile /var/lib/ntp/ntp.drift
+disable monitor
+
+restrict default ignore
+restrict 127.0.0.1 mask 255.0.0.0
+restrict 169.254.169.123 nomodify notrap
+
+server 169.254.169.123 prefer iburst
+EOT
+else
+  echo "USING DEFAULT NTP CONFIGURATION"
+fi
+
+service ntp restart
+
+echo "--------------------------------------"
 echo "        Installing Docker"
 echo "--------------------------------------"
 apt-get install -y apt-transport-https ca-certificates curl software-properties-common

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -14,6 +14,29 @@ echo "     Performing System Updates"
 echo "-------------------------------------------"
 apt-get update && apt-get -y upgrade
 
+echo "--------------------------------------"
+echo "        Installing NTP"
+echo "--------------------------------------"
+apt-get install -y ntp
+
+# Use AWS NTP config for EC2 instances and default for non-AWS
+if [ -f /sys/hypervisor/uuid ] && [ `head -c 3 /sys/hypervisor/uuid` == ec2 ]; then
+cat <<EOT > /etc/ntp.conf
+driftfile /var/lib/ntp/ntp.drift
+disable monitor
+
+restrict default ignore
+restrict 127.0.0.1 mask 255.0.0.0
+restrict 169.254.169.123 nomodify notrap
+
+server 169.254.169.123 prefer iburst
+EOT
+else
+  echo "USING DEFAULT NTP CONFIGURATION"
+fi
+
+service ntp restart
+
 echo "--------------------------------------------"
 echo "       Setting Private IP"
 echo "--------------------------------------------"


### PR DESCRIPTION
There are times where builds will stop running because the builder are out of sync with the services box.  Adding NTP to everything should help resolve this problem.

The script is configured to use Amazon's NTP servers if it detects we are running on an EC2 instance and the default config for non-AWS instances.