### PR TITLE
Use /bin/bash to avoid issues with ntp configuration

### DIFF
--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 set -exu
 


### PR DESCRIPTION
After latest PR i am having issues on nomad nodes:

```
+ [ -f /sys/hypervisor/uuid ]
+ head -c 3 /sys/hypervisor/uuid
+ [ ec2 == ec2 ]
test.sh: 2: [: ec2: unexpected operator
+ echo USING DEFAULT NTP CONFIGURATION
USING DEFAULT NTP CONFIGURATION
```

Reason is that we are using `bash` but not `sh` syntax