### PR TITLE
Update terraform version to 0.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   terraform:
     docker:
-      - image: hashicorp/terraform:0.9.9
+      - image: hashicorp/terraform:0.11.14
     working_directory: ~/terraform
     steps:
       - checkout


### PR DESCRIPTION
This brings our builds and tests up to the terraform 0.11 to match our recommendation on which version to use.