### PR TITLE
[RE-28] Make the user_data_flag a bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ Optional vars:
   | enable_route | Enable creating a Route53 route for the Services box | 0 |
   | route_name | Route name to configure for Services box | "" |
   | route_zone_id | Zone to configure route in | "" |
-  | services_user_data_enabled | Set to 0 to disable automated installation on Services Box | 1 |
+  | services_user_data_enabled | Enable/disable automated installation on Services Box | true |
   | force_destroy_s3_bucket | Add/Remove ability to forcefully destroy S3 bucket | false |
   | services_disable_api_termination | Protect the services instance from API termination | true |

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,7 @@ variable "no_proxy" {
 
 variable "services_user_data_enabled" {
   description = "Disable User Data for Services Box"
-  default     = "1"
+  default     = "true"
 }
 
 variable "legacy_builder_spot_price" {


### PR DESCRIPTION
The services_user_data_enabled flag is used as a bool, so it's default should be a bool.