### PR TITLE
(RE-133) Update default 1.0 builder instance type

### DIFF
--- a/terraform.tfvars.template
+++ b/terraform.tfvars.template
@@ -15,7 +15,7 @@ aws_ssh_key_name = "..."
 
 circle_secret_passphrase = "..."
 services_instance_type = "m4.2xlarge"
-builder_instance_type = "r3.4xlarge"
+builder_instance_type = "r4.4xlarge"
 nomad_client_instance_type = "m4.2xlarge"
 
 #####################################


### PR DESCRIPTION
The `r3.4xlarge` is now a previous generation instance type and will cause a problem setting up server for the first time if this is left as a default - AWS will throw an invalid instance type error.

This PR bumps the instance type included by default to the equivalent, current generation - `r4.4xlarge`.