### PR TITLE
Added thumbs.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **.retry
 /.terraform
 .DS_Store
+thumbs.db


### PR DESCRIPTION
## Description 
`thumbs.db` is a windows directory cache file which sometimes gets pushed to repos, comes in commits, and can trouble other users. Now windows users can send PRs without having to worry about `thumbs.db`.