### PR TITLE
[DON'T MERGE UNTIL 2.19.0][RE-236] Update Nomad and Docker versions

### DIFF
--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -79,7 +79,7 @@ cat <<EOT > /etc/nomad/config.hcl
 log_level = "DEBUG"
 name = "$INSTANCE_ID"
 data_dir = "/opt/nomad"
-datacenter = "us-east-1"
+datacenter = "default"
 advertise {
     http = "$PRIVATE_IP"
     rpc = "$PRIVATE_IP"

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -45,7 +45,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=18.09.9~3-0~ubuntu-xenial
+apt-get -y install docker-ce=5:18.09.9~3-0~ubuntu-xenial
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -45,7 +45,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-xenial
+apt-get -y install docker-ce=18.09.9~3-0~ubuntu-xenial
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq
@@ -65,7 +65,7 @@ echo "--------------------------------------"
 echo "         Installing nomad"
 echo "--------------------------------------"
 apt-get install -y zip
-curl -o nomad.zip https://releases.hashicorp.com/nomad/0.5.6/nomad_0.5.6_linux_amd64.zip
+curl -o nomad.zip https://releases.hashicorp.com/nomad/0.9.3/nomad_0.9.3_linux_amd64.zip
 unzip nomad.zip
 mv nomad /usr/bin
 


### PR DESCRIPTION
Update Nomad and Docker to the versions used by cloud.

Also, we don't run multiple datacenters, and us-east-1 was a lie. Cloud always used default so we have hardcoded that value in schedulerer.