### PR TITLE
[RE-270][RE-271] Add Support for GovCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Optional vars:
   | services_instance_type | Instance type for the centralized services box.  We recommend a m4 instance | m5.2xlarge |
   | builder_instance_type | Instance type for the 1.0 builder machines.  We recommend a r3 instance | r5.2xlarge |
   | max_builders_count | Max number of 1.0 builders | 2 |
-  | nomad_client_instance_type | Instance type for the nomad clients (2.0 builders). We recommend a XYZ instance | m5.xlarge |
+  | nomad_client_instance_type | Instance type for the nomad clients (2.0 builders). We recommend a XYZ instance | m5.2xlarge |
   | max_clients_count | Max number of nomad clients | 2 |
   | prefix   | Prefix for resource names | circleci |
   | enable_nomad | Provisions a nomad cluster for CCIE v2 | 1 |

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Optional vars:
 
   | Var      | Description | Default |
   | -------- | ----------- | ------- |
-  | services_instance_type | Instance type for the centralized services box.  We recommend a m4 instance | m4.2xlarge |
-  | builder_instance_type | Instance type for the 1.0 builder machines.  We recommend a r3 instance | r3.2xlarge |
+  | services_instance_type | Instance type for the centralized services box.  We recommend a m4 instance | m5.2xlarge |
+  | builder_instance_type | Instance type for the 1.0 builder machines.  We recommend a r3 instance | r5.2xlarge |
   | max_builders_count | Max number of 1.0 builders | 2 |
-  | nomad_client_instance_type | Instance type for the nomad clients (2.0 builders). We recommend a XYZ instance | m4.xlarge |
+  | nomad_client_instance_type | Instance type for the nomad clients (2.0 builders). We recommend a XYZ instance | m5.xlarge |
   | max_clients_count | Max number of nomad clients | 2 |
   | prefix   | Prefix for resource names | circleci |
   | enable_nomad | Provisions a nomad cluster for CCIE v2 | 1 |

--- a/circleci.tf
+++ b/circleci.tf
@@ -22,6 +22,7 @@ data "template_file" "circleci_policy" {
   template = file("templates/circleci_policy.tpl")
 
   vars = {
+    aws_partition = var.enable_govcloud == true ? "aws-us-gov" : "aws"
     bucket_arn    = aws_s3_bucket.circleci_bucket.arn
     sqs_queue_arn = module.shutdown_sqs.sqs_arn
     role_name     = aws_iam_role.circleci_role.name

--- a/modules/nomad/variables.tf
+++ b/modules/nomad/variables.tf
@@ -29,7 +29,7 @@ variable "os" {
 }
 
 variable "instance_type" {
-  default = "m4.xlarge"
+  default = "m5.xlarge"
 }
 
 variable "services_private_ip" {

--- a/templates/circleci_policy.tpl
+++ b/templates/circleci_policy.tpl
@@ -35,7 +35,7 @@
                   "ec2:CreateTags"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:ec2:${aws_region}:*"
+              "Resource": "arn:${aws_partition}:ec2:${aws_region}:*"
           },
           {
               "Action": [
@@ -54,7 +54,7 @@
                   "ec2:DeleteVolume"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:ec2:${aws_region}:*:*/*",
+              "Resource": "arn:${aws_partition}:ec2:${aws_region}:*:*/*",
               "Condition": {
                   "StringEquals": {
                       "ec2:ResourceTag/ManagedBy": "circleci-vm-service"
@@ -66,7 +66,7 @@
                  "sts:AssumeRole"
               ],
               "Resource": [
-                  "arn:aws:iam::*:role/${role_name}"
+                  "arn:${aws_partition}:iam::*:role/${role_name}"
               ],
               "Effect": "Allow"
           }

--- a/terraform.tfvars-dev.template
+++ b/terraform.tfvars-dev.template
@@ -4,9 +4,9 @@ aws_region = "..."
 aws_vpc_id = "..."
 aws_subnet_id = "..."
 aws_ssh_key_name = "..."
-services_instance_type = "m4.2xlarge"
-builder_instance_type = "t2.2xlarge"
-nomad_client_instance_type = "t2.2xlarge"
+services_instance_type = "t3.2xlarge"
+builder_instance_type = "t3.2xlarge"
+nomad_client_instance_type = "t3.2xlarge"
 desired_builders_count = "1"
 
 # Passphrase used for encryping/decrypting secrets—must not be blank

--- a/terraform.tfvars.template
+++ b/terraform.tfvars.template
@@ -13,9 +13,9 @@ aws_ssh_key_name = "..."
 # 2. Required CircleCI Configuration
 #####################################
 
-services_instance_type = "m4.2xlarge"
-builder_instance_type = "r3.4xlarge"
-nomad_client_instance_type = "m4.2xlarge"
+services_instance_type = "m5.2xlarge"
+builder_instance_type = "r5.2xlarge"
+nomad_client_instance_type = "m5.2xlarge"
 
 # Passphrase used for encryping/decrypting secrets—must not be blank
 circle_secret_passphrase = "..."

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "enable_nomad" {
 
 variable "nomad_client_instance_type" {
   description = "instance type for the nomad clients. It must be a valid aws instance type."
-  default     = "m5.xlarge"
+  default     = "m5.2xlarge"
 }
 
 variable "prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,12 +38,12 @@ variable "services_ami" {
 
 variable "services_instance_type" {
   description = "instance type for the centralized services box.  We recommend a m4.2xlarge instance, with 32G of RAM"
-  default     = "m4.2xlarge"
+  default     = "m5.2xlarge"
 }
 
 variable "builder_instance_type" {
   description = "instance type for the builder machines.  We recommend a r3 instance"
-  default     = "r3.2xlarge"
+  default     = "r5.2xlarge"
 }
 
 variable "max_builders_count" {
@@ -63,7 +63,7 @@ variable "enable_nomad" {
 
 variable "nomad_client_instance_type" {
   description = "instance type for the nomad clients. It must be a valid aws instance type."
-  default     = "m4.xlarge"
+  default     = "m5.xlarge"
 }
 
 variable "prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,11 @@ variable "aws_ssh_key_name" {
   description = "The SSH key to be used for the instances"
 }
 
+variable "enable_govcloud" {
+  description = "Allows deployment into AWS GovCloud"
+  default = "false"
+}
+
 variable "circle_secret_passphrase" {
   description = "Decryption key for secrets used by CircleCI machines"
 }


### PR DESCRIPTION
- Add GovCloud Support
  - Create a new flag to toggle GovCloud support.  The flag will adjust the ARN Partitions (aws/aws-gov-cloud) within the IAM policy.
- Update VM Service AWS Instance Types
  - GovCloud does not support t2 or m4 insatnce types.  Updated the default values to t3 and m5 types.