### PR TITLE
Detect private IP address by routing table

### DIFF
--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -72,7 +72,7 @@ mv nomad /usr/bin
 echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
-export PRIVATE_IP="$(/sbin/ifconfig ens3 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+export PRIVATE_IP="$(/sbin/ip route get ${nomad_server} | head -n 1 | awk '{ print $5 }')"
 export INSTANCE_ID="$(curl $aws_instance_metadata_url/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -72,7 +72,7 @@ mv nomad /usr/bin
 echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
-export PRIVATE_IP="$(/sbin/ip route get ${nomad_server} | head -n 1 | awk '{ print $5 }')"
+export PRIVATE_IP="$(/sbin/ip route get ${nomad_server} | head -n 1 | grep -oP 'src\s+\S*' | awk '{ print $2 }')"
 export INSTANCE_ID="$(curl $aws_instance_metadata_url/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl


### PR DESCRIPTION
# Description
This PR intends to change the logic to detect a private IP address for a Nomad client, so that the programme detects the address by checking the source address it will use to communicate with its Nomad server.

## Background
Originally, it was designed to guess the private IP address by getting an address which is bound to `ens3`. It is not a good thing to do because:
* That is no longer `ens3` but `ens5`, even for the default configuration (as far as I checked with my own test environment on EC2).
* Hardcoding NIC names is not a good idea. In modern environments with systemd/udevd, ["an administrator now has to check first what the local interface name is before they can invoke commands on it"](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/#comeagainwhatgooddoesthisdo).

## Impact without this change
Without this change, installation of CircleCI Server will fail under certain circumstances, especially if AWS VPCs with `enableDnsHostnames` disabled. Note that this situation can happen very easily because it is disabled by default for the VPCs created with "Create new" button in the "Your VPCs" view.

## Justification for the approach of this code change
Unlike the approach suggested in #135, the change in this PR tries to detect IP addresses by using generic features provided by the Linux kernel (i.e. `iproute2`). That should increase interoperability and robustness against possible spec changes in AWS.

# Fixed Issues
#135

# Contribution checklist
☑️ I have read the Contributing Guidelines
☑️ Commits have been made with meaningful commit messages
☑️ All automated tests have passed successfully