### PR TITLE
Allow packets to/from ::/0 for SGs which allow packets to/from 0.0.0.0/0

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -109,6 +109,7 @@ resource "aws_security_group" "circleci_builders_sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 
@@ -129,6 +130,7 @@ resource "aws_security_group" "circleci_services_sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
   # If using github.com (not GitHub Enterprise) whitelist GitHub cidr block
   # https://help.github.com/articles/what-ip-addresses-does-github-use-that-i-should-whitelist/
@@ -172,6 +174,7 @@ resource "aws_security_group" "circleci_users_sg" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 22
     to_port     = 22
@@ -180,6 +183,7 @@ resource "aws_security_group" "circleci_users_sg" {
   # For Web traffic to services
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
@@ -187,6 +191,7 @@ resource "aws_security_group" "circleci_users_sg" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
@@ -194,6 +199,7 @@ resource "aws_security_group" "circleci_users_sg" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 8800
     to_port     = 8800
@@ -235,6 +241,7 @@ resource "aws_security_group" "circleci_users_sg" {
   # TODO: Update once services box has ngrok
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 64535
     to_port     = 65535
@@ -249,6 +256,7 @@ resource "aws_security_group" "circleci_vm_sg" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 22
     to_port     = 22
@@ -257,6 +265,7 @@ resource "aws_security_group" "circleci_vm_sg" {
   # For Web traffic to services
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 2376
     to_port     = 2376
@@ -265,6 +274,7 @@ resource "aws_security_group" "circleci_vm_sg" {
   # For SSHing into 2.0 build
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 54782
     to_port     = 54782
@@ -275,6 +285,7 @@ resource "aws_security_group" "circleci_vm_sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 

--- a/modules/nomad/main.tf
+++ b/modules/nomad/main.tf
@@ -25,6 +25,7 @@ resource "aws_security_group" "nomad_sg" {
     to_port     = 65535
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   egress {
@@ -32,6 +33,7 @@ resource "aws_security_group" "nomad_sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 
@@ -46,6 +48,7 @@ resource "aws_security_group" "ssh_sg" {
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   egress {
@@ -53,6 +56,7 @@ resource "aws_security_group" "ssh_sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 


### PR DESCRIPTION
# Description
This PR intends to add rules in Security Groups so that communications over IPv6 are allowed for the VMs initiated by Terraform.

## Impact 
Without this change, installation of CircleCI Server could fail (or at least would not complete within reasonable time) if the targeted VPC has IPv6 enabled.

This is because i) `apt-get update` [here](https://github.com/circleci/enterprise-setup/blob/master/templates/services_user_data.tpl#L15) will use IPv6 if the VPC is IPv6-ready and the VM receives an IPv6 address, ii) the `apt-get update` will not proceed until it times out because the egress packets IPv6 are silently dropped, and iii) the `apt-get update` could eventually fail, that should cause installation failure in total.

**There is no workaround for this issue, as long as IPv6 is enabled for the targeted VPC.**

## Fixed Issues
No issue ticket is filed yet for this issue. I'm creating this PR as soon as I found the issue.

# Contribution checklist
☑️ I have read the Contributing Guidelines
☑️ Commits have been made with meaningful commit messages
☑️ All automated tests have passed successfully