### PR TITLE
Set Replicated version to match version set in Replicated config

### DIFF
--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -exu
-REPLICATED_VERSION="2.42.2"
+REPLICATED_VERSION="2.38.6"
 UNAME="$(uname -r)"
 
 export http_proxy="${http_proxy}"


### PR DESCRIPTION
We are currently ahead of the minor version we are using in our configs.  Dialing back to latest 2.38 patch.