### PR TITLE
[CIRCLE-26218] Modify policy to allow calls to iam:GetRole

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -26,6 +26,7 @@ data "template_file" "circleci_policy" {
     bucket_arn    = aws_s3_bucket.circleci_bucket.arn
     sqs_queue_arn = module.shutdown_sqs.sqs_arn
     role_name     = aws_iam_role.circleci_role.name
+    role_path     = aws_iam_role.circleci_role.path
     aws_region    = var.aws_region
   }
 }

--- a/templates/circleci_policy.tpl
+++ b/templates/circleci_policy.tpl
@@ -63,10 +63,11 @@
           },
           {
               "Action": [
+                 "iam:GetRole",
                  "sts:AssumeRole"
               ],
               "Resource": [
-                  "arn:${aws_partition}:iam::*:role/${role_name}"
+                  "arn:${aws_partition}:iam::*:role${role_path}${role_name}"
               ],
               "Effect": "Allow"
           }


### PR DESCRIPTION
As of
https://github.com/circleci/picard-services/commit/764d5519cc820dc8583780ab12528a7a71b53933,
output-processor now needs to call iam:GetRole, so we need to modify
the policy to allow this.