### PR TITLE
Update Docker version to 18.09.3 for services box

### DIFF
--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -55,7 +55,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update
 apt-get install -y "linux-image-$UNAME"
-apt-get -y install docker-ce="17.12.1~ce-0~ubuntu"
+apt-get -y install docker-ce="5:18.09.9~3-0~ubuntu-xenial"
 
 echo "--------------------------------------------"
 echo "       Installing Replicated"


### PR DESCRIPTION
This updates the docker version the services box downloads and installs during startup.
I believe this to cover the work from RE-517 but please let me know if I got it wrong.

I tested a complete terraform destroy + terraform apply cycle to make sure that the changes don't break anything.